### PR TITLE
Clamp slice-density quantile probability at 0.99

### DIFF
--- a/R/forest_inventory.R
+++ b/R/forest_inventory.R
@@ -276,7 +276,7 @@ forest_inventory <- function(las,
     } else if (nrow(slice) < 100 | use_stem_segmentation) {
       planes <- slice
     } else {
-      q <- 1 - sqrt(100 / nrow(slice)) + 0.05
+      q <- min(0.99, 1 - sqrt(100 / nrow(slice)) + 0.05)
       planes <- slice[
         Planarity  > quantile(Planarity,  q) &
           Verticality > quantile(Verticality, q)


### PR DESCRIPTION
### Bug
`forest_inventory()` errors with `'probs' outside [0,1]` when any TreeID's per-slice point count exceeds ~38,000. Reproducible with TLS / handheld SLAM scans of mature stands at ~1 cm voxel thinning.

### Cause
In `.fit_circle()` (within `forest_inventory()`):

```r
q <- 1 - sqrt(100 / nrow(slice)) + 0.05
```

When nrow(slice) > ~38,000, 1 - sqrt(100/nrow) + 0.05 exceeds 1 and quantile() aborts with 'probs' outside [0,1].

### Fix
The function already gates the small-slice case (nrow(slice) < 100) where the heuristic would degenerate. This adds the symmetric upper bound for the large-slice case. Behavior is unchanged for any slice that previously worked (the formula stayed below 0.99 for nrow(slice) < ~38,000).

### Testing
R CMD check (via devtools::check) on R 4.5.2 / Windows: 0 errors, 0 warnings, 0 notes.

Verified on a dense handheld SLAM TLS plot (~19M points, ~80 stems) that previously crashed mid-forest_inventory(); the function now completes and returns sensible DBH / Height / ConvexHullArea values.

### Notes
Minimal one-line bounds check; no algorithmic changes.